### PR TITLE
switched from include to include_once in types 

### DIFF
--- a/types.php
+++ b/types.php
@@ -26,17 +26,17 @@ $fm_controlTypes = array('default' => 			'fm_controlBase',
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 //control base class
-include 'types/base.php';
+include_once 'types/base.php';
 
 //control types
-include 'types/separator.php';
-include 'types/text.php';
-include 'types/textarea.php';
-include 'types/checkbox.php';
-include 'types/list.php';
-include 'types/note.php';
-include 'types/recaptcha.php';
-include 'types/file.php';
+include_once 'types/separator.php';
+include_once 'types/text.php';
+include_once 'types/textarea.php';
+include_once 'types/checkbox.php';
+include_once 'types/list.php';
+include_once 'types/note.php';
+include_once 'types/recaptcha.php';
+include_once 'types/file.php';
 
 //'panel' helpers
 include 'types/panelhelper.php';


### PR DESCRIPTION
Currently implementing custom control types is problematic as it leads to classic chicken-egg problem.
Base classes (e.g. fm_controlBase) are included in types.php.
The same types.php contains code which adds custom control types (via fm_control_types filter).
There is no way to extend the base classes from another plugin and have them registered using this mechnism.

Proposed changes solve the problem partially. After switching to include_once, base type classes can be included_once in custom plugins to enable extension and there is no "Cannot redeclare class" problem anymore.

Remaining problem is that fm_control_types filter is used when Form Manager is loaded and some custom plugins might not be loaded at that time yet (i.e. custom plugin needs to be loaded before Form Manager to have the types registered).
